### PR TITLE
Add 'accessibilityLabel' field as one of the properties for the RadioButton elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Example uses default styles by RadioGroup<br><br>
 npm install react-native-custom-radio-group --save
 ```
 <strong>Props</strong>:<br>
-* radioGroupList (<i>Required</i>) : An array of object; object => {label: '', value: ''}
+* radioGroupList (<i>Required</i>) : An array of object; object => {label: '', value: '', accessibilityLabel: ''}
 * onChange: CallBack with the value of selected radio button
 * initialValue: Value of the option to be initially selected
 * containerStyle: Style of the radio group container
@@ -45,12 +45,15 @@ export default class MyComponent extends Component {
 //radioGroupList.js
 export const radioGroupList = [{
   label: 'Car',
-  value: 'transport_car'
+  value: 'transport_car',
+  accessibilityLabel: 'Car'
 }, {
   label: 'Bike',
-  value: 'transport_bike'
+  value: 'transport_bike',
+  accessibilityLabel: 'Bike'
 }, {
   label: 'Bus',
-  value: 'transport_bus'
+  value: 'transport_bus',
+  accessibilityLabel: 'Bus'
 }];
 ```

--- a/lib/RadioButton.component.js
+++ b/lib/RadioButton.component.js
@@ -10,14 +10,14 @@ class RadioButton extends Component {
     radioSelect(index, value);
   }
   render () {
-    const {active, label, buttonContainerStyle, buttonTextStyle,
+    const {active, label, accessibilityLabel, buttonContainerStyle, buttonTextStyle,
     buttonContainerActiveStyle, buttonContainerInactiveStyle, buttonTextActiveStyle,
     buttonTextInactiveStyle} = this.props;
 
     const activeContainerStyles = active ? [styles.active, buttonContainerActiveStyle] : [styles.inactive, buttonContainerInactiveStyle];
     const activeTextStyles = active ? [styles.activeText, buttonTextActiveStyle] : [styles.inactiveText, buttonTextInactiveStyle];
     return (
-      <TouchableWithoutFeedback onPress={this.onToggle}>
+      <TouchableWithoutFeedback onPress={this.onToggle} accessibilityLabel={accessibilityLabel}>
         <View style={[styles.container, buttonContainerStyle, activeContainerStyles]}>
           <Text style={[styles.text, buttonTextStyle, activeTextStyles]}>{label}</Text>
         </View>
@@ -29,6 +29,7 @@ RadioButton.defaultProps = {
   active: false,
   label: '',
   value: '',
+  accessibilityLabel: '',
   radioSelect: noop,
   buttonContainerStyle: {},
   buttonTextStyle: {},
@@ -42,6 +43,7 @@ RadioButton.propTypes = {
   active: Proptypes.bool,
   label: Proptypes.string,
   value: Proptypes.string,
+  accessibilityLabel: Proptypes.string,
   radioSelect: Proptypes.func,
   buttonContainerStyle: Proptypes.object,
   buttonTextStyle: Proptypes.object,

--- a/lib/RadioGroup.component.js
+++ b/lib/RadioGroup.component.js
@@ -26,7 +26,7 @@ class RadioGroup extends Component {
     const radioGroup = map(radioGroupList, (radiocomp, index) =>
 
       <RadioButton key={index} label={result(radiocomp, 'label', '')}
-        value={result(radiocomp, 'value', '')} index={index}
+        value={result(radiocomp, 'value', '')} index={index} accessibilityLabel={result(radiocomp, 'accessibilityLabel', '')}
         radioSelect={this.radioSelect} active={selected === index}
         buttonContainerStyle={buttonContainerStyle} buttonTextStyle={buttonTextStyle}
         buttonContainerActiveStyle={buttonContainerActiveStyle} buttonContainerInactiveStyle={buttonContainerInactiveStyle}


### PR DESCRIPTION
Since there is no possibility to modify the accessibilityLabel for a RadioButton element, I think it could be useful to add it.